### PR TITLE
V2.21.9 versioning error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Energy System Description Language (ESDL)
 
-The Energy System description Language (ESDL) is a modeling language created for modeling the components in an energy system and their relations towards each other. Furthermore ESDL is capable of expressing the dynamic behavior of components in the energy system. For instance the power consumption of an neighborhood. ESDL describes components by their basic functionality (Energy Capabilities), these are modeled in 5 abstract categories: Production, Consumption, Storage, Transport and Conversion. ESDL enables energy modelers to model a complex energy system in a generic way. The language is machine readable so makers of energy transition calculation tools and GIS applications can support ESDL in order to enforce the interoperability of their products.
+The Energy System Description Language (ESDL) is a modelling language created for modelling the components in an energy system and their relations towards each other. Furthermore ESDL is capable of expressing the dynamic behavior of components in the energy system. For instance the power consumption of a neighborhood. ESDL describes components by their basic functionalities (Energy Capabilities) which are modelled in 5 abstract categories: Production, Consumption, Storage, Transport and Conversion. ESDL enables energy modellers to model a complex energy system in a generic way. The language is machine readable so makers of energy transition calculation tools and GIS applications can support ESDL in order to enforce the interoperability of their products.
 
 # Why ESDL
-The energy system is in a transition towards a sustainable, less CO2 emitting system. Achieving this requires large adaptions of the structure and behavior of the energy system. Furthermore a comprehensive insight in the system is necessary. However the energy system is complex. It exists out of a vast number of assets/components which are connect to each other via various types of infrastructures. Besides that to fully understand the dynamics of an energy system, comprehending the dynamic behavior of the assets/components required. ESDL aims to model this complex structure and behavior of the energy system into one generic language. Resulting in a harmonized way of modeling energy data, this enables reusability and interoperability.
+The energy system is in a transition towards a sustainable, less CO2 emitting system. Achieving this requires large adaptions of the structure and behavior of the energy system. Furthermore a comprehensive insight in the system is necessary. However the energy system is complex. It exists out of a vast number of assets/components which are connected to each other via various types of infrastructures. Besides that to fully understand the dynamics of an energy system, comprehending the dynamic behavior of the assets/components required. ESDL aims to model this complex structure and behavior of the energy system into one generic language. Resulting in a harmonized way of modeling energy data, this enables reusability and interoperability.
 
 # Example application areas
 ESDL can be used for: 
 
-* Energy transition calculation tools: common language for energy transition calculation tools. To describe inputs and outputs of those tools. 
-* Energy Information System: ESDL can be used as a basis for a central energy information system where the energy system of a certain region is registered. 
-* ESDL can be used as a language for (local) governments to model and share their (local) energy system. 
+* Energy transition calculation tools: A common language for energy transition calculation tools. To describe inputs and outputs of those tools. 
+* Energy Information System: A basis for a central energy information system where the energy system of a certain region is registered. 
+* ESDL can be used as a language for (local) governments to model and share their (local) energy system information. 
 * Monitoring evolution of an energy system: Furthermore, multiple ESDL snapshots of a certain area over time provide insight in the evolution of an energy system. 
 
 # Getting started
@@ -26,7 +26,7 @@ https://energytransition.gitbook.io/esdl/esdl-based-tools
 Those pages describe (graphical)editors for ESDL, Java integration and Python integration examples
 
 # Contribute to ESDL
-Contriubtions to ESDL can be done by pull requests.
+Contributions to ESDL can be done by pull requests.
 
 If you want to contact the ESDL team, please follow this [link](https://www.tno.nl/nl/aandachtsgebieden/informatie-communicatie-technologie/expertisegroepen/monitoring-control-services/grip-op-de-energietransitie-met-esdl/)
 

--- a/esdl.edit/META-INF/MANIFEST.MF
+++ b/esdl.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: esdl.edit;singleton:=true
 Automatic-Module-Name: esdl.edit
-Bundle-Version: 2.21.6
+Bundle-Version: 2.21.9
 Bundle-ClassPath: .
 Bundle-Activator: esdl.provider.EsdlEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/esdl.editor/META-INF/MANIFEST.MF
+++ b/esdl.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: esdl.editor;singleton:=true
 Automatic-Module-Name: esdl.editor
-Bundle-Version: 2.21.6
+Bundle-Version: 2.21.9
 Bundle-ClassPath: .
 Bundle-Activator: esdl.presentation.EsdlEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/esdl/META-INF/MANIFEST.MF
+++ b/esdl/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: esdl;singleton:=true
 Automatic-Module-Name: esdl
-Bundle-Version: 2.21.6
+Bundle-Version: 2.21.9
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/esdl/pom.xml
+++ b/esdl/pom.xml
@@ -176,7 +176,7 @@
 					<dependency>
 						<groupId>nl.tno.esdl</groupId>
 						<artifactId>esdl.buildtools</artifactId>
-						<version>2.21.6</version>
+						<version>2.21.9</version>
 						<type>eclipse-plugin</type>
 					</dependency>
 					<dependency>


### PR DESCRIPTION
1.  Corrected version numbers in MANIFEST files and in pom.xml which caused Java class generation to break.
2.  Corrected minor grammatical mistakes in README.md